### PR TITLE
テーブルのコメントをテーブル名の隣に出力

### DIFF
--- a/desc_tables.sh
+++ b/desc_tables.sh
@@ -23,9 +23,11 @@ fi
 exec 1> >(cat > $OUT)
 
 echo "# ${DB}"
-for table in `MYSQL_PWD=${PASSWORD} mysql -h${HOST} -u${USER} -P ${PORT} -e "show tables;" -N ${DB}`
+for table_info in `MYSQL_PWD=${PASSWORD} mysql -h${HOST} -u${USER} -P ${PORT} -e "show table status;" -N ${DB}`
 do
-  echo "## ${table}"
+  table=`echo ${table_info} | cut -f1`
+  table_comment=`echo ${table_info} | cut -f18`
+  echo "## ${table} [${table_comment}]"
 
   # テーブル定義の出力
   echo '### Fields'


### PR DESCRIPTION
テーブルのコメントが出力されていなかったので、テーブル名の隣に出力するように修正しました。